### PR TITLE
Update 01-introduction.md

### DIFF
--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -4,8 +4,8 @@ sidebar_position: 1
 
 # Introduction
 
-JunoTools is a swiss knife that helps you build on Juno by providing smart contract front ends.
-We call these front-end apps as **Smart Contact Dashboard** or **sc dashboard** as short.
+JunoTools is a Swiss Army knife that helps you build on Juno by providing smart contract front ends.
+We call these front-end apps **Smart Contact Dashboard** or **sc dashboard** for short.
 
 Using the dashboards is **free** for everyone, and will always be.
 
@@ -14,7 +14,7 @@ Using the dashboards is **free** for everyone, and will always be.
 To quickly use the dashboard, simply jump to the following sections
 
 - [Airdrop](/03-dashboards/02-airdrop/01-introduction.md)
-- [CW-20](/03-dashboards/04-cw-20/01-introduction.md)
+- [CW20](/03-dashboards/04-cw-20/01-introduction.md)
 - [Sign and Verify](/03-dashboards/05-sign-and-verify/01-introduction.md)
 
-If you want to learn more about the birth, vision, and roadmap of JunoTools,  head to the [concept page](02-concept.md).
+If you want to learn more about the birth, vision, and roadmap of JunoTools,  head to the [Concept page](02-concept.md).


### PR DESCRIPTION
Corrected nonstandard hyphenation of "CW20" and capitalization of "Swiss", added "Army" to make it "Swiss Army knife" because that is the typical usage, gave initial caps to "Concept" page, changed "as short" to "for short".